### PR TITLE
Remove force reconnect on each print

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-cleversolutions-zebraprinter",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -924,7 +924,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -942,11 +943,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -959,15 +962,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1070,7 +1076,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1080,6 +1087,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1092,17 +1100,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1119,6 +1130,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1191,7 +1203,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1201,6 +1214,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1276,7 +1290,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1306,6 +1321,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1323,6 +1339,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1361,11 +1378,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca-cleversolutions-zebraprinter",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Zebra Printer Cordova Plugin for iOS and Android",
   "cordova": {
     "id": "ca-cleversolutions-zebraprinter",

--- a/src/ios/ZebraPrinter/ZebraPrinterPlugin.swift
+++ b/src/ios/ZebraPrinter/ZebraPrinterPlugin.swift
@@ -5,7 +5,7 @@ import ExternalAccessory
 class ZebraPrinterPlugin: CDVPlugin {
     var printerConnection: ZebraPrinterConnection?
     var printer: ZebraPrinter?
-    
+
     /**
      * Discover connectable zebra printers
      *
@@ -14,7 +14,7 @@ class ZebraPrinterPlugin: CDVPlugin {
         DispatchQueue.global(qos: .background).async {
             let manager = EAAccessoryManager.shared()
             let accessories = manager.connectedAccessories
-            
+
             var devices = [Any]()
             accessories.forEach { (accessory) in
                 let name = accessory.name
@@ -36,7 +36,7 @@ class ZebraPrinterPlugin: CDVPlugin {
             )
         }
     }
-    
+
     /**
      * Get the status of the printer we are currently connected to
      *
@@ -54,7 +54,7 @@ class ZebraPrinterPlugin: CDVPlugin {
             status["isHeadOpen"] = false
             status["isHeadCold"] = false
             status["isPartialFormatInProgress"] = false
-            
+
             if(self.printerConnection != nil && self.printerConnection!.isConnected() && self.printer != nil){
                 let zebraPrinterStatus = try? self.printer?.getCurrentStatus()
                 if(zebraPrinterStatus != nil){
@@ -69,7 +69,7 @@ class ZebraPrinterPlugin: CDVPlugin {
                             NSLog("Printer Not Ready.")
                         }
                     }
-                    
+
                     status["connected"] = true
                     status["isReadyToPrint"] = zebraPrinterStatus?.isReadyToPrint
                     status["isPaused"] = zebraPrinterStatus?.isPaused
@@ -80,7 +80,7 @@ class ZebraPrinterPlugin: CDVPlugin {
                     status["isHeadOpen"] = zebraPrinterStatus?.isHeadOpen
                     status["isHeadCold"] = zebraPrinterStatus?.isHeadCold
                     status["isPartialFormatInProgress"] = zebraPrinterStatus?.isPartialFormatInProgress
-                    
+
                     NSLog("ZebraPrinter:: returning status")
                     let pluginResult = CDVPluginResult(
                         status: CDVCommandStatus_OK,
@@ -119,7 +119,7 @@ class ZebraPrinterPlugin: CDVPlugin {
             }
         }
     }
-    
+
     /**
      * Print the cpcl
      *
@@ -130,10 +130,6 @@ class ZebraPrinterPlugin: CDVPlugin {
             if( self.isConnected()){
                 let data = cpcl.data(using: .utf8)
                 var error: NSError?
-                // it seems self.isConnected() can lie if the printer has power cycled
-                // a workaround is to close and reopen the connection
-                self.printerConnection!.close()
-                self.printerConnection!.open()
                 self.printerConnection!.write(data, error:&error)
                 if error != nil{
                     NSLog("ZebraPrinter:: error printing -> " + (error?.localizedDescription ?? "Unknonwn Error"))
@@ -167,7 +163,7 @@ class ZebraPrinterPlugin: CDVPlugin {
             }
         }
     }
-    
+
     /**
      * Check if we are connectd to the printer or not
      *
@@ -211,29 +207,29 @@ class ZebraPrinterPlugin: CDVPlugin {
                 )
                 return
             }
-            
+
             NSLog("ZebraPrinter:: connecting to " + address)
-            
+
             //try to close an existing connection
             if(self.printerConnection != nil){
                 self.printerConnection?.close()
             }
-            
+
             //clear out our existing printer & connection
             self.printerConnection = nil;
             self.printer = nil;
-            
+
             //create and open a new connection
             self.printerConnection = MfiBtPrinterConnection(serialNumber: address)
             NSLog("ZebraPrinter:: got connection. opening...")
             self.printerConnection?.open()
             NSLog("ZebraPrinter:: opened connection")
-            
+
             if( self.isConnected()){
                 NSLog("ZebraPrinter:: getting printer")
                 self.printer = try? ZebraPrinterFactory.getInstance(self.printerConnection as? NSObjectProtocol & ZebraPrinterConnection)
                 NSLog("ZebraPrinter:: got printer")
-                
+
                 if(self.printer == nil)
                 {
                     NSLog("ZebraPrinter:: nil printer")
@@ -281,7 +277,7 @@ class ZebraPrinterPlugin: CDVPlugin {
             self.printerConnection = nil
             self.printer = nil
         }
-        
+
         let pluginResult = CDVPluginResult(
             status: CDVCommandStatus_OK
         )
@@ -289,5 +285,5 @@ class ZebraPrinterPlugin: CDVPlugin {
             pluginResult,
             callbackId: command.callbackId
         )
-    }    
+    }
 }


### PR DESCRIPTION
High print latency was caused by closing and opening the printer
connection on each write. The reason given for this was that
isConnected() can lie. In scenarios where the printer was power
cycled, the reconnect did not actually reopen the connection
with the printer.